### PR TITLE
Add Rsbuild plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ npx zod-compiler generate src/ --strip-unknown-keys
 | SWC        | `import zodCompiler from "zod-compiler/swc"`      |
 | Rollup     | `import zodCompiler from "zod-compiler/rollup"`   |
 | Rolldown   | `import zodCompiler from "zod-compiler/rolldown"` |
+| Rsbuild    | `import zodCompiler from "zod-compiler/rsbuild"`  |
 | rspack     | `import zodCompiler from "zod-compiler/rspack"`   |
 | Bun        | `import zodCompiler from "zod-compiler/bun"`      |
 | Farm       | `import zodCompiler from "zod-compiler/farm"`     |
@@ -163,6 +164,17 @@ npx zod-compiler generate src/ --strip-unknown-keys
 zodCompiler({
   include: ["src/schemas"],
   verbose: true,
+});
+```
+
+**rsbuild.config.ts:**
+
+```typescript
+import { defineConfig } from "@rsbuild/core";
+import zodCompiler from "zod-compiler/rsbuild";
+
+export default defineConfig({
+  plugins: [zodCompiler()],
 });
 ```
 

--- a/apps/rsbuild/package.json
+++ b/apps/rsbuild/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@zod-compiler/rsbuild",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "start": "node dist/index.mjs",
+    "test": "pnpm build && pnpm start"
+  },
+  "dependencies": {
+    "zod": "catalog:",
+    "zod-compiler": "workspace:*"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "^2.1.7",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/rsbuild/rsbuild.config.ts
+++ b/apps/rsbuild/rsbuild.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@rsbuild/core";
+import zodCompiler from "zod-compiler/rsbuild";
+
+export default defineConfig({
+  plugins: [zodCompiler({ verbose: true })],
+  source: {
+    entry: {
+      index: "./src/main.ts",
+    },
+  },
+  output: {
+    target: "node",
+    distPath: {
+      root: "dist",
+    },
+    filename: {
+      js: "[name].mjs",
+    },
+  },
+});

--- a/apps/rsbuild/src/main.ts
+++ b/apps/rsbuild/src/main.ts
@@ -1,0 +1,8 @@
+import { strict as assert } from "node:assert";
+import { UserSchema } from "./schemas.js";
+
+assert.equal(UserSchema.safeParse({ name: "Nestor", email: "nestor@example.com" }).success, true);
+assert.equal(UserSchema.safeParse({ name: "", email: "invalid" }).success, false);
+
+// oxlint-disable-next-line no-console -- integration fixture output
+console.log("Rsbuild integration passed.");

--- a/apps/rsbuild/src/schemas.ts
+++ b/apps/rsbuild/src/schemas.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const UserSchema = z.object({
+  name: z.string().min(1),
+  email: z.email(),
+});

--- a/apps/rsbuild/tsconfig.json
+++ b/apps/rsbuild/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "rsbuild.config.ts"]
+}

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,7 @@
   "workspaces": {
     ".": {
       "entry": [
-        "src/unplugin/{bun,esbuild,farm,rolldown,rollup,rspack,vite,webpack}.ts",
+        "src/unplugin/{bun,esbuild,farm,rolldown,rollup,rsbuild,rspack,vite,webpack}.ts",
         "tests/compat.mjs"
       ],
       "project": ["src/**/*.ts", "tests/**/*.{ts,mjs}"],

--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
       "import": "./dist/unplugin/rspack.js",
       "default": "./dist/unplugin/rspack.js"
     },
+    "./rsbuild": {
+      "types": "./dist/unplugin/rsbuild.d.ts",
+      "source": "./src/unplugin/rsbuild.ts",
+      "import": "./dist/unplugin/rsbuild.js",
+      "default": "./dist/unplugin/rsbuild.js"
+    },
     "./farm": {
       "types": "./dist/unplugin/farm.d.ts",
       "source": "./src/unplugin/farm.ts",
@@ -107,6 +113,7 @@
   },
   "devDependencies": {
     "@jridgewell/trace-mapping": "^0.3.31",
+    "@rsbuild/core": "^2.1.7",
     "@swc/core": "^1.15.43",
     "@types/node": "catalog:",
     "@types/picomatch": "^4.0.3",
@@ -121,10 +128,14 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@rsbuild/core": "^1.0.0 || ^2.0.0",
     "@swc/core": ">=1.3.0",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    },
     "@swc/core": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,12 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.31
         version: 0.3.31
+      '@rsbuild/core':
+        specifier: ^2.1.7
+        version: 2.1.7
       '@swc/core':
         specifier: ^1.15.43
-        version: 1.15.43
+        version: 1.15.43(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -153,6 +156,25 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@types/node@25.9.1)(@vitest/coverage-v8@4.1.4)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/rsbuild:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+      zod-compiler:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@rsbuild/core':
+        specifier: ^2.1.7
+        version: 2.1.7
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   apps/rspack:
     dependencies:
       zod:
@@ -164,10 +186,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ^2.0.5
-        version: 2.0.5(@rspack/core@2.0.5)
+        version: 2.0.5(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@rspack/core':
         specifier: ^2.0.5
-        version: 2.0.5
+        version: 2.0.5(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -332,11 +354,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -680,6 +711,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1772,8 +1809,23 @@ packages:
       rollup:
         optional: true
 
+  '@rsbuild/core@2.1.7':
+    resolution: {integrity: sha512-Xhs8DkLw2Vk5ydwjNG3GMJe1h03lqlCO4dV9EOG9HSR6vDfh07K48aq3KJ8/ncEL/YuFBaCIJrVc7rMFoR1y7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rspack/binding-darwin-arm64@2.0.5':
     resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-arm64@2.1.5':
+    resolution: {integrity: sha512-XLAN6YSU36qkciJtV9DY9z57pdHOjKy/f1HyoqpZenRg8p46jnXPziV45lfrTZpG+FF6g/jtTUc4dKbeyoWqPw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1782,8 +1834,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.1.5':
+    resolution: {integrity: sha512-KLW7PV86jyCOyqJSqrkZdvYUWYCFX/Q4LsGmVc8tyDA8jBYLMHJDewC/lNf9ot3rU2SoLDZKhDUh7q7dX0FRmg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.0.5':
     resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    resolution: {integrity: sha512-KOooAC8L+Ljx5sY7ZuMeaXCQ310FNWaPWXcYQJpFPApF3qyLeSfuOftUGwxcxeo5U0mS5OY3zxp7/5CaHWKYjg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1794,8 +1857,32 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.5':
+    resolution: {integrity: sha512-0GFc07gT71+uRbHtejDecBfSL0fs7dQAwCtXYieXboACauL7UvS3Hwr6v8A91aGtAcvLotnCaIa3CWWYwtYlYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    resolution: {integrity: sha512-isQQDp3fBzPSZpLVFzPqVXIVA4I9b9mKs58TfUgOzDP/1g1582YSV3iFopgFogvEliihXDuuXvM6aAkP+w8Z+Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
+    resolution: {integrity: sha512-/SP6VknY4kH60BYplI2FDNAJCo4U4DUszLxhKsgVlgA5ImgHC8Ew2AsKgidk7ceiYV9OcKzYuWYe9tVpysBYVA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.5':
     resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    resolution: {integrity: sha512-/GJmS+buA4pilT10gs5mfAhAZxSHXpDD8veZ3QpYvNUuoU9gvempAq9TgjbyNN/vc5pf76GdXPXKFMiehudYSA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1806,12 +1893,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.5':
+    resolution: {integrity: sha512-iwS3t75nZ2TnUjB05KtvpvjpdkOy/nLxbaOnwjbdnNZZXpUaMadLbllGAWayHPGCMsL2yKBEhVEESZpR7tK3SA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.5':
     resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    resolution: {integrity: sha512-jOhW69t1H/jcRaSMB5U8jVzWP18j0YQIlo0nT8W+KvNVScJeyOze4FFc+5RIS7VmuT8/jid7hUyydZOfm6UgqA==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.5':
     resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
+    resolution: {integrity: sha512-OLfMXmtFBcrWr9BRGKXJYrWgYR0JSaoAWr3EVFDjKGi/YR5aUwQSGc3AJPBph9g0YsdSqRuUhtQGtCk84DeeEA==}
     cpu: [arm64]
     os: [win32]
 
@@ -1820,13 +1922,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    resolution: {integrity: sha512-p4OSmnj21+AY8vpIADveLEBXfXJRXonOTYim2VLVWV4TbXfhYNMLiX3qESHCdNnn6lVJM0q6zxxzEUfTyAKydw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.5':
     resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.1.5':
+    resolution: {integrity: sha512-YCkLLDGMkHsw5CpcsFtFhzCu+JZEsNrcH9O1GpWMkyxR2ku2Fq1i2wEHYSm26HyW+PJ3+Fv347MPWMFZIz9q2g==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.0.5':
     resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
+
+  '@rspack/binding@2.1.5':
+    resolution: {integrity: sha512-lF3ZLeeyV0AN3BL0m2jAmNZD5pP9IHsQ8gUXN7mo0g4xsW6nf6hsN7o9CnEHECz5uUZb+EoWsuWzAAmnA9Ip8Q==}
 
   '@rspack/cli@2.0.5':
     resolution: {integrity: sha512-AAyuY/8sfegb0IcsFEhn5gLOTxy1uDmwjP49RY81PENz2pCk/7NU0zDdt0ke5wmpOH5s6IxS+Kw4aWdvl8FGpQ==}
@@ -1840,6 +1955,18 @@ packages:
 
   '@rspack/core@2.0.5':
     resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.5':
+    resolution: {integrity: sha512-YHjL7xVXycAWsjJtF39cRZ2u+ddiNFxY+FcNgEBe6Y8OaLeUfMfjba3gK+B1Oj32UcKD6BmXGsPfu9p+OII/Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1989,6 +2116,9 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
@@ -2007,6 +2137,9 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/bun@1.3.14':
     resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
@@ -4267,12 +4400,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4488,6 +4637,13 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@next/env@16.2.6': {}
@@ -5083,22 +5239,53 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.4
 
+  '@rsbuild/core@2.1.7':
+    dependencies:
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rspack/binding-darwin-arm64@2.0.5':
+    optional: true
+
+  '@rspack/binding-darwin-arm64@2.1.5':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.5':
     optional: true
 
+  '@rspack/binding-darwin-x64@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-arm64-gnu@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.5':
     optional: true
 
+  '@rspack/binding-linux-arm64-musl@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-x64-gnu@2.0.5':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.5':
@@ -5108,13 +5295,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.5':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding@2.0.5':
@@ -5130,13 +5333,36 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.5
       '@rspack/binding-win32-x64-msvc': 2.0.5
 
-  '@rspack/cli@2.0.5(@rspack/core@2.0.5)':
-    dependencies:
-      '@rspack/core': 2.0.5
+  '@rspack/binding@2.1.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.5
+      '@rspack/binding-darwin-x64': 2.1.5
+      '@rspack/binding-linux-arm64-gnu': 2.1.5
+      '@rspack/binding-linux-arm64-musl': 2.1.5
+      '@rspack/binding-linux-riscv64-gnu': 2.1.5
+      '@rspack/binding-linux-riscv64-musl': 2.1.5
+      '@rspack/binding-linux-x64-gnu': 2.1.5
+      '@rspack/binding-linux-x64-musl': 2.1.5
+      '@rspack/binding-wasm32-wasi': 2.1.5
+      '@rspack/binding-win32-arm64-msvc': 2.1.5
+      '@rspack/binding-win32-ia32-msvc': 2.1.5
+      '@rspack/binding-win32-x64-msvc': 2.1.5
 
-  '@rspack/core@2.0.5':
+  '@rspack/cli@2.0.5(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+
+  '@rspack/core@2.0.5(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.5
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.1.5(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.5
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -5257,7 +5483,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.15.43':
     optional: true
 
-  '@swc/core@1.15.43':
+  '@swc/core@1.15.43(@swc/helpers@0.5.23)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.27
@@ -5274,10 +5500,15 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.15.43
       '@swc/core-win32-ia32-msvc': 1.15.43
       '@swc/core-win32-x64-msvc': 1.15.43
+      '@swc/helpers': 0.5.23
 
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -5295,6 +5526,11 @@ snapshots:
       typescript: 6.0.3
 
   '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true

--- a/src/unplugin/rsbuild.ts
+++ b/src/unplugin/rsbuild.ts
@@ -1,0 +1,15 @@
+import type { RsbuildPlugin } from "@rsbuild/core";
+import type { ZodCompilerPluginOptions } from "./types.js";
+import zodCompilerRspack from "./rspack.js";
+
+export default function zodCompiler(options?: ZodCompilerPluginOptions): RsbuildPlugin {
+  return {
+    name: "zod-compiler",
+    setup(api) {
+      api.modifyRspackConfig((config) => {
+        config.plugins ??= [];
+        config.plugins.push(zodCompilerRspack(options));
+      });
+    },
+  };
+}

--- a/tests/unplugin/rsbuild.test.ts
+++ b/tests/unplugin/rsbuild.test.ts
@@ -1,0 +1,25 @@
+import type { ModifyRspackConfigFn, RsbuildPluginAPI } from "@rsbuild/core";
+import { describe, expect, it } from "vitest";
+import zodCompiler from "#src/unplugin/rsbuild.js";
+
+describe("rsbuild plugin", () => {
+  it("installs the rspack adapter", async () => {
+    const modifiers: ModifyRspackConfigFn[] = [];
+    const plugin = zodCompiler({ cache: false });
+    const api = {
+      modifyRspackConfig(modifier: ModifyRspackConfigFn) {
+        modifiers.push(modifier);
+      },
+    } as unknown as RsbuildPluginAPI;
+
+    await plugin.setup(api);
+
+    expect(plugin.name).toBe("zod-compiler");
+    expect(modifiers).toHaveLength(1);
+
+    const config = { plugins: [] };
+    await modifiers[0]?.(config, {} as never);
+
+    expect(config.plugins).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an Rsbuild plugin so people can use zod-compiler in an Rsbuild config the same way they use the Vite plugin.

## Changes

- Adds the `zod-compiler/rsbuild` import.
- Reuses the existing Rspack plugin under Rsbuild.
- Adds a small Rsbuild example, test, and README instructions.

## Testing

- `pnpm build`
- `pnpm lint`
- `pnpm test`
- `pnpm --filter @zod-compiler/rsbuild test`
