### PR TITLE
perf: cache repeated compiler analyses

### DIFF
--- a/src/core/codegen/build-path.ts
+++ b/src/core/codegen/build-path.ts
@@ -83,6 +83,10 @@ interface BuildGen {
   rebuilds: ReadonlySet<SchemaIR>;
 }
 
+// Extraction freezes the effective IR shape for codegen, so every later query
+// for the same root can reuse this otherwise whole-tree analysis.
+const rebuildSetCache = new WeakMap<SchemaIR, ReadonlySet<SchemaIR>>();
+
 /**
  * Which nodes of `root` produce a value that is not their input — a stripping
  * object, coercion, codec, default, overwrite or transform, including
@@ -97,6 +101,9 @@ interface BuildGen {
  * fixpoint settles the mutual dependency between the two.
  */
 function rebuildSet(root: SchemaIR): ReadonlySet<SchemaIR> {
+  const cached = rebuildSetCache.get(root);
+  if (cached !== undefined) return cached;
+
   const targets = new Map<number, SchemaIR>([[0, root]]);
   const nodes: SchemaIR[] = [];
   const seen = new Set<SchemaIR>();
@@ -109,6 +116,10 @@ function rebuildSet(root: SchemaIR): ReadonlySet<SchemaIR> {
   };
   collect(root);
 
+  // Children are collected after their parents. Walking in reverse resolves
+  // every acyclic dependency in one pass; only recursive back-edges can require
+  // another iteration.
+  nodes.reverse();
   const rebuilds = new Set<SchemaIR>();
   for (let changed = true; changed;) {
     changed = false;
@@ -149,6 +160,7 @@ function rebuildSet(root: SchemaIR): ReadonlySet<SchemaIR> {
       }
     }
   }
+  rebuildSetCache.set(root, rebuilds);
   return rebuilds;
 }
 

--- a/src/core/codegen/context.ts
+++ b/src/core/codegen/context.ts
@@ -801,15 +801,6 @@ function hasSuperRefine(checks: readonly { kind: string }[] | undefined): boolea
 }
 
 /**
- * Check if a SchemaIR tree produces output that is not the input itself —
- * either value-mutating operations (coerce, default, catch, overwrite) that
- * write back to the input expression, or a strip object that rebuilds a fresh
- * object from its known keys. Used by container generators to decide whether to
- * clone (so the rebuilt/mutated value never writes through to the caller's
- * input), by generateValidator to keep such schemas off the by-reference fast
- * path, and by the shared-walk dedup + intersection extractor to exclude them.
- */
-/**
  * Can this tuple's output be LONGER than its input?
  *
  * `handleTupleResult` assigns `final.value[i] = result.value` for every item it
@@ -826,7 +817,28 @@ export function tuplePadsShortInput(ir: SchemaIR & { type: "tuple" }): boolean {
   return ir.items.some((item, index) => index < ir.optStart && !rejectsUndefined(item));
 }
 
+// SchemaIR is immutable after extraction and shared nodes are common, making
+// mutation an identity-stable property worth computing only once.
+const mutationCache = new WeakMap<SchemaIR, boolean>();
+
+/**
+ * Check if a SchemaIR tree produces output that is not the input itself —
+ * either value-mutating operations (coerce, default, catch, overwrite) that
+ * write back to the input expression, or a strip object that rebuilds a fresh
+ * object from its known keys. Used by container generators to decide whether to
+ * clone (so the rebuilt/mutated value never writes through to the caller's
+ * input), by generateValidator to keep such schemas off the by-reference fast
+ * path, and by the shared-walk dedup + intersection extractor to exclude them.
+ */
 export function hasMutation(ir: SchemaIR): boolean {
+  const cached = mutationCache.get(ir);
+  if (cached !== undefined) return cached;
+  const result = computeHasMutation(ir);
+  mutationCache.set(ir, result);
+  return result;
+}
+
+function computeHasMutation(ir: SchemaIR): boolean {
   switch (ir.type) {
     case "string":
       // url checks trim (and optionally normalize) the value; overwrite

--- a/src/core/codegen/dedupe.ts
+++ b/src/core/codegen/dedupe.ts
@@ -89,6 +89,10 @@ export function createSharedSchemaPlan(
 ): SharedSchemaPlan {
   const keyMemo = new Map<SchemaIR, string>();
   const weightMemo = new Map<SchemaIR, number>();
+  // Candidate subtrees overlap heavily; memoization prevents every parent
+  // candidate from recursively qualifying the same descendants again.
+  const recursiveRefMemo = new Map<SchemaIR, boolean>();
+  const exportRefMemo = new Map<SchemaIR, boolean>();
   const stats = new Map<string, { ir: SchemaIR; count: number; weight: number }>();
 
   for (const root of roots) {
@@ -100,8 +104,8 @@ export function createSharedSchemaPlan(
       (c) =>
         c.count >= 2 &&
         c.weight >= MIN_SHARED_WEIGHT &&
-        !containsRecursiveRef(c.ir) &&
-        !referencesExportRefs(c.ir),
+        !containsRecursiveRef(c.ir, recursiveRefMemo) &&
+        !referencesExportRefs(c.ir, exportRefMemo),
     )
     // Largest shapes first so the biggest wins get the lowest indices; tie-break
     // on the structural key for deterministic, reproducible output.
@@ -169,7 +173,15 @@ export function createSharedSchemaPlan(
  * `source` instead of `refIndex` and is hosted into the shared block's preamble,
  * so it does not disqualify a shape.
  */
-function referencesExportRefs(ir: SchemaIR): boolean {
+function referencesExportRefs(ir: SchemaIR, memo: Map<SchemaIR, boolean>): boolean {
+  const cached = memo.get(ir);
+  if (cached !== undefined) return cached;
+  const result = referencesExportRefsUncached(ir, memo);
+  memo.set(ir, result);
+  return result;
+}
+
+function referencesExportRefsUncached(ir: SchemaIR, memo: Map<SchemaIR, boolean>): boolean {
   switch (ir.type) {
     case "default":
     case "catch":
@@ -215,7 +227,7 @@ function referencesExportRefs(ir: SchemaIR): boolean {
     default:
       break;
   }
-  return childSchemas(ir).some(referencesExportRefs);
+  return childSchemas(ir).some((child) => referencesExportRefs(child, memo));
 }
 
 // ─── Candidate collection ────────────────────────────────────────────────────
@@ -283,9 +295,14 @@ function weightOf(ir: SchemaIR, memo: Map<SchemaIR, number>): number {
   return weight;
 }
 
-function containsRecursiveRef(ir: SchemaIR): boolean {
-  if (ir.type === "recursiveRef") return true;
-  return childSchemas(ir).some(containsRecursiveRef);
+function containsRecursiveRef(ir: SchemaIR, memo: Map<SchemaIR, boolean>): boolean {
+  const cached = memo.get(ir);
+  if (cached !== undefined) return cached;
+  const result =
+    ir.type === "recursiveRef" ||
+    childSchemas(ir).some((child) => containsRecursiveRef(child, memo));
+  memo.set(ir, result);
+  return result;
 }
 
 // ─── Structural keys ─────────────────────────────────────────────────────────

--- a/src/core/codegen/well-known-regex.ts
+++ b/src/core/codegen/well-known-regex.ts
@@ -146,9 +146,17 @@ export function lookupFastRegexSource(source: string): string | null {
  * reporting the ORIGINAL source in issues — see `emitRegexSourceString`.
  */
 export function fastTestSource(source: string): string | null {
+  // Repeat unrolling is deterministic by source and the same formats recur
+  // across validators and constant-pooling regeneration passes.
+  const cached = FAST_TEST_SOURCE_CACHE.get(source);
+  if (cached !== undefined) return cached === false ? null : cached;
   const tableRewrite = SOURCE_TO_TEST_SOURCE.get(source) ?? null;
-  return unrollRepeats(tableRewrite ?? source) ?? tableRewrite;
+  const result = unrollRepeats(tableRewrite ?? source) ?? tableRewrite;
+  FAST_TEST_SOURCE_CACHE.set(source, result ?? false);
+  return result;
 }
+
+const FAST_TEST_SOURCE_CACHE = new Map<string, string | false>();
 
 /**
  * Virtual-module export name for the ORIGINAL `/source/` pattern string of a

--- a/src/core/extract/effects.ts
+++ b/src/core/extract/effects.ts
@@ -7,6 +7,35 @@
 import type { Node } from "acorn";
 import { parseExpressionAt } from "acorn";
 
+interface ParsedCallback {
+  ast: Node | null;
+  source: string;
+}
+
+const parsedCallbacks = new WeakMap<Function, ParsedCallback>();
+
+function parseCallback(fn: Function): ParsedCallback {
+  // A callback can occur in several schemas and preprocess classification asks
+  // two questions about it consecutively. Parse its stable source only once.
+  const cached = parsedCallbacks.get(fn);
+  if (cached !== undefined) return cached;
+  const source = fn.toString();
+  let ast: Node | null = null;
+  if (!source.includes("[native code]")) {
+    try {
+      ast = parseExpressionAt(source, 0, {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      });
+    } catch {
+      // Unsupported callback syntax remains non-inlineable.
+    }
+  }
+  const parsed = { ast, source };
+  parsedCallbacks.set(fn, parsed);
+  return parsed;
+}
+
 // Well-known globals that are safe to reference in inlined functions
 const SAFE_GLOBALS = new Set([
   "undefined",
@@ -70,15 +99,8 @@ export function isReferenceablePredicate(fn: unknown): boolean {
  */
 export function isContextFreeUnaryCallback(fn: unknown): boolean {
   if (!isReferenceablePredicate(fn)) return false;
-  let ast: Node;
-  try {
-    ast = parseExpressionAt((fn as Function).toString(), 0, {
-      ecmaVersion: "latest",
-      sourceType: "module",
-    });
-  } catch {
-    return false;
-  }
+  const { ast } = parseCallback(fn as Function);
+  if (ast === null) return false;
   const fnNode = ast as { params?: Node[]; body?: Node };
   if ((fnNode.params?.length ?? 0) > 1) return false;
   if (fnNode.params?.some((param) => param.type === "RestElement")) return false;
@@ -118,22 +140,8 @@ export function isPayloadCheck(check: {
  */
 export function tryCompileEffect(fn: unknown): string | undefined {
   if (typeof fn !== "function") return undefined;
-
-  const source = fn.toString();
-
-  // Quick reject: native functions
-  if (source.includes("[native code]")) return undefined;
-
-  let ast: Node;
-  try {
-    ast = parseExpressionAt(source, 0, {
-      ecmaVersion: "latest",
-      sourceType: "module",
-    });
-  } catch {
-    // Parse failed — likely TypeScript annotations or unsupported syntax
-    return undefined;
-  }
+  const { ast, source } = parseCallback(fn);
+  if (ast === null) return undefined;
 
   // Reject async and generator functions
   if ("async" in ast && (ast as { async?: boolean }).async) return undefined;

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -69,7 +69,10 @@ function referenceCount(source: string, name: string): number {
 function planSharedConstants(
   results: readonly CompiledSchemaInfo[],
   constantsByResult: ReadonlyMap<CodeGenResult, readonly GeneratedConstant[]>,
-): ReadonlyMap<string, string> {
+): {
+  names: ReadonlyMap<string, string>;
+  users: ReadonlySet<CodeGenResult>;
+} {
   const byInitializer = new Map<string, { kind: ConstantKind; users: Set<CodeGenResult> }>();
   for (const { codegenResult } of results) {
     const source = `${codegenResult.code}\n${codegenResult.functionDef}`;
@@ -103,13 +106,18 @@ function planSharedConstants(
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 
   const nextIndex = new Map<ConstantKind, number>();
-  return new Map(
+  // Keep the exact first-pass users so unrelated validators retain their
+  // already-generated code instead of paying the complete second pass.
+  const users = new Set<CodeGenResult>();
+  const names = new Map(
     repeated.map(([initializer, entry]) => {
+      for (const user of entry.users) users.add(user);
       const index = nextIndex.get(entry.kind) ?? 0;
       nextIndex.set(entry.kind, index + 1);
       return [initializer, `__zc${entry.kind}_${index}`];
     }),
   );
+  return { names, users };
 }
 
 function emitSharedConstants(sharedConstantNames: ReadonlyMap<string, string>): string {
@@ -216,13 +224,16 @@ export function compileSchemas(
       refEntries,
     }),
   );
-  const sharedConstantNames = planSharedConstants(initialResults, constantsByResult);
+  const sharedConstants = planSharedConstants(initialResults, constantsByResult);
+  const sharedConstantNames = sharedConstants.names;
 
   // Regenerate only when sharing is profitable. Selecting shared names before
   // emission avoids textual rewriting of generated JavaScript, where a user
   // enum string can legally contain text resembling a generated identifier.
   if (sharedConstantNames.size > 0) {
     for (const entry of generated) {
+      // Non-users contain no declaration selected for module-scope sharing.
+      if (!sharedConstants.users.has(entry.codegenResult)) continue;
       entry.codegenResult = generateValidator(entry.ir, entry.exportName, {
         refCount: entry.refEntries.length,
         mode: options.mode,


### PR DESCRIPTION
## Summary

- cache rebuild analysis per immutable IR root and process acyclic children in reverse traversal order
- memoize mutation and shared-schema candidate qualification for overlapping IR subtrees
- regenerate only validators that actually use selected shared constants
- cache callback parsing by function identity and regex optimization by source

Split from #17 at the maintainer's request so these compiler hot-path changes remain independently reviewable and bisectable.

## Validation

- `vp run ci`
- 128 test files passed
- 3,413 tests passed, 1 skipped